### PR TITLE
Add MineClone support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,6 +10,12 @@ License:
 	
 		Maciej Kasatkin / RealBadAngel ( GNU LGPLv2+ ) ( https://github.com/minetest-mods/technic/blob/master/technic_chests/register.lua ):
 			file: /inventorybags/sort_inventory_function.lua
+
+		MineClone 2 support: ThePython10110 (GPLv3)
+			Files: Parts of README.txt, mod.conf, settingtypes.txt, init.lua, crafting.lua, bags.lua, and devices.lua
+
+			Everything should work exactly the same way in MineClone as Minetest game, except for the fact that the
+			Bag of Winds does nothing (and is therefore disabled in MineClone)
 	
 		Everything else:
 		cx384 ( GNU GPLv3  )

--- a/bags.lua
+++ b/bags.lua
@@ -1,28 +1,28 @@
 
 local function get_formspec(name, width, height)
-	local sizewidth = inventory_bags.width
+	local sizewidth = inventorybags.width
 	local txpos = (sizewidth-width)/2
-	if width >= inventory_bags.width then
+	if width >= inventorybags.width then
 		sizewidth = width
 		txpos = 0
 	end
 	local bag_formspec =
 		"size[".. sizewidth ..",".. height+5 .."]" ..
-		inventory_bags.gui_bg ..
-		inventory_bags.gui_bg_img ..
-		inventory_bags.gui_slots ..
+		inventorybags.gui_bg ..
+		inventorybags.gui_bg_img ..
+		inventorybags.gui_slots ..
 		"list[detached:"..name..";main;".. txpos ..",0;".. width ..",".. height ..";]"
-		if inventory_bags.game == "mtg" then
+		if inventorybags.game == "mtg" then
 			bag_formspec = bag_formspec..
-			"list[current_player;main;".. (sizewidth-inventory_bags.width)/2 ..",".. height+0.85 ..";"..inventory_bags.width..",1;]" ..
-			"list[current_player;main;".. (sizewidth-inventory_bags.width)/2 ..",".. height+2.08 ..";"..inventory_bags.width..",3;"..inventory_bags.width.."]"..
-			inventory_bags.get_hotbar_bg((sizewidth-inventory_bags.width)/2,height+0.85)
+			"list[current_player;main;".. (sizewidth-inventorybags.width)/2 ..",".. height+0.85 ..";"..inventorybags.width..",1;]" ..
+			"list[current_player;main;".. (sizewidth-inventorybags.width)/2 ..",".. height+2.08 ..";"..inventorybags.width..",3;"..inventorybags.width.."]"..
+			inventorybags.get_hotbar_bg((sizewidth-inventorybags.width)/2,height+0.85)
 		else
 			bag_formspec = bag_formspec..
-			"list[current_player;main;".. (sizewidth-inventory_bags.width)/2 ..",".. height+0.85 ..";"..inventory_bags.width..",3;"..inventory_bags.width.."]"..
-			mcl_formspec.get_itemslot_bg((sizewidth-inventory_bags.width)/2, height+0.85,inventory_bags.width,3)..
-			"list[current_player;main;".. (sizewidth-inventory_bags.width)/2 ..",".. height+4.08 ..";"..inventory_bags.width..",1;]"..
-			mcl_formspec.get_itemslot_bg((sizewidth-inventory_bags.width)/2, height+4.08,inventory_bags.width,1)..
+			"list[current_player;main;".. (sizewidth-inventorybags.width)/2 ..",".. height+0.85 ..";"..inventorybags.width..",3;"..inventorybags.width.."]"..
+			mcl_formspec.get_itemslot_bg((sizewidth-inventorybags.width)/2, height+0.85,inventorybags.width,3)..
+			"list[current_player;main;".. (sizewidth-inventorybags.width)/2 ..",".. height+4.08 ..";"..inventorybags.width..",1;]"..
+			mcl_formspec.get_itemslot_bg((sizewidth-inventorybags.width)/2, height+4.08,inventorybags.width,1)..
 			mcl_formspec.get_itemslot_bg(txpos, 0, width, height)
 		end
 		bag_formspec = bag_formspec..
@@ -565,19 +565,19 @@ if minetest.settings:get_bool("inventorybags_enable_item_teleportation_bag", fal
 	end)
 end
 
-if minetest.get_modpath("xdecor") or inventory_bags.game == "mcl" then
+if minetest.get_modpath("xdecor") or inventorybags.game == "mcl" then
 	local ender_chest_formspec
-	if inventory_bags.game == "mtg" then
+	if inventorybags.game == "mtg" then
 		ender_chest_formspec = "size[8,9]" ..
-		inventory_bags.gui_bg ..
-		inventory_bags.gui_bg_img ..
-		inventory_bags.gui_slots ..
+		inventorybags.gui_bg ..
+		inventorybags.gui_bg_img ..
+		inventorybags.gui_slots ..
 		"list[current_player;enderchest;0,0.3;8,4;]" ..
 		"list[current_player;main;0,4.85;8,1;]" ..
 		"list[current_player;main;0,6.08;8,3;8]" ..
 		"listring[current_player;enderchest]" ..
 		"listring[current_player;main]" ..
-		inventory_bags.get_hotbar_bg(0,4.85)
+		inventorybags.get_hotbar_bg(0,4.85)
 	else
 		ender_chest_formspec = "size[9,8.75]"..
 		"label[0,0;"..minetest.formspec_escape(minetest.colorize("#313131", "Ender Bag")).."]"..
@@ -628,15 +628,15 @@ if minetest.get_modpath("more_chests") then
 			minetest.sound_play("inventorybags_open_teleportation_bag", {gain = 0.8, object = user, max_hear_distance = 5})
 			minetest.show_formspec(user:get_player_name(), "inventorybags:wifi_bag",
 				"size[8,9]" ..
-				inventory_bags.gui_bg ..
-				inventory_bags.gui_bg_img ..
-				inventory_bags.gui_slots ..
+				inventorybags.gui_bg ..
+				inventorybags.gui_bg_img ..
+				inventorybags.gui_slots ..
 				"list[current_player;more_chests:wifi;0,0.3;8,4;]" ..
 				"list[current_player;main;0,4.85;8,1;]" ..
 				"list[current_player;main;0,6.08;8,3;8]" ..
 				"listring[current_player;more_chests:wifi]" ..
 				"listring[current_player;main]" ..
-				inventory_bags.get_hotbar_bg(0,4.85)
+				inventorybags.get_hotbar_bg(0,4.85)
 			)
 			return itemstack
 		end,
@@ -644,15 +644,15 @@ if minetest.get_modpath("more_chests") then
 			minetest.sound_play("inventorybags_open_teleportation_bag", {gain = 0.8, object = placer, max_hear_distance = 5})
 			minetest.show_formspec(placer:get_player_name(), "inventorybags:wifi_bag",
 				"size[8,9]" ..
-				inventory_bags.gui_bg ..
-				inventory_bags.gui_bg_img ..
-				inventory_bags.gui_slots ..
+				inventorybags.gui_bg ..
+				inventorybags.gui_bg_img ..
+				inventorybags.gui_slots ..
 				"list[current_player;more_chests:wifi;0,0.3;8,4;]" ..
 				"list[current_player;main;0,4.85;8,1;]" ..
 				"list[current_player;main;0,6.08;8,3;8]" ..
 				"listring[current_player;more_chests:wifi]" ..
 				"listring[current_player;main]" ..
-				inventory_bags.get_hotbar_bg(0,4.85)
+				inventorybags.get_hotbar_bg(0,4.85)
 			)
 			return itemstack
 		end
@@ -668,7 +668,7 @@ if minetest.get_modpath("more_chests") then
 	end)
 end
 
-if minetest.get_modpath("beds") or inventory_bags.game == "mcl" then
+if minetest.get_modpath("beds") or inventorybags.game == "mcl" then
 	local bedfunction = cause_an_error_if_this_isnt_set
 	if minetest.get_modpath("beds") then
 		bedfunction = function(player)
@@ -695,7 +695,7 @@ if minetest.get_modpath("beds") or inventory_bags.game == "mcl" then
 	})
 end
 
-if (not minetest.settings:get_bool("inventorybags_disable_bag_of_winds", false)) and (inventory_bags.game ~= "mcl") then
+if (not minetest.settings:get_bool("inventorybags_disable_bag_of_winds", false)) and (inventorybags.game ~= "mcl") then
 
 	local gravity_change = -1.5
 

--- a/crafting.lua
+++ b/crafting.lua
@@ -1,4 +1,4 @@
-minetest.log(inventorybags.game)
+--minetest.log(inventorybags.game)
 
 local items = {
 	steel_ingot = {mtg = "default:steel_ingot", mcl = "mcl_core:iron_ingot"},

--- a/crafting.lua
+++ b/crafting.lua
@@ -1,20 +1,55 @@
+minetest.log(inventory_bags.game)
+
+local items = {
+	steel_ingot = {mtg = "default:steel_ingot", mcl = "mcl_core:iron_ingot"},
+	gold_ingot = {mtg = "default:gold_ingot", mcl = "mcl_core:gold_ingot"},
+	obsidian_glass = {mtg = "default:obsidian_glass", mcl = "mcl_amethyst:tinted_glass"},
+	mese_lamp = {mtg = "default:meselamp", mcl = "mesecons_lightstone:lightstone_off"},
+	mese_crystal = {mtg = "default:mese_crystal", mcl = "mesecons_torch:redstoneblock"},
+	mese_crystal_fragment = {mtg = "default:mese_crystal_fragment", mcl = "mesecons:redstone"},
+	paper = {mtg = "default:paper", mcl = "mcl_core:paper"},
+	cyan_dye = {mtg = "dye:cyan", mcl = "mcl_dye:cyan"},
+	magenta_dye = {mtg = "dye:magenta", mcl = "mcl_dye:magenta"},
+	yellow_dye = {mtg = "dye:yellow", mcl = "mcl_dye:yellow"},
+	black_dye = {mtg = "dye:black", mcl = "mcl_dye:black"},
+	white_dye = {mtg = "dye:white", mcl = "mcl_dye:white"},
+	red_dye = {mtg = "dye:red", mcl = "mcl_dye:red"},
+	green_dye = {mtg = "dye:green", mcl = "mcl_dye:green"},
+	blue_dye = {mtg = "dye:blue", mcl = "mcl_dye:blue"},
+	steel_ladder = {mtg = "default:steel_ladder", mcl = "mcl_core:lapis"},
+	lava_bucket = {mtg = "bucket:bucket_lava", mcl = "mcl_buckets:bucket_lava"},
+	empty_bucket = {mtg = "bucket:bucket_empty", mcl = "mcl_buckets:bucket_lava"},
+	bronze_ingot = {mtg = "default:bronze_ingot", mcl = "mcl_copper:copper_ingot"},
+	gunpowder = {mtg = "tnt:gunpowder", mcl = "mcl_mobitems:gunpowder"},
+	tnt = {mtg = "tnt:tnt", mcl = "mcl_tnt:tnt"},
+	steel_block = {mtg = "default:steelblock", mcl = "mcl_core:ironblock"},
+	gold_block = {mtg = "default:goldblock", mcl = "mcl_core:goldblock"},
+	diamond_block = {mtg = "default:diamondblock", mcl = "mcl_core:diamondblock"},
+	chest = {mtg = "default:chest", mcl = "mcl_chests:chest"},
+	diamond = {mtg = "default:diamond", mcl = "mcl_core:diamond"},
+	mese_block = {mtg = "default:mese", mcl = "mcl_core:lapisblock"},
+	ender_chest = {mtg = "xdecor:enderchest", mcl = "mcl_chests:ender_chest"},
+	red_wool = {mtg = "wool:red", mcl = "mcl_wool:red"},
+	white_wool = {mtg = "wool:white", mcl = "mcl_wool:red"},
+}
+
 -- Craftitem / Misc
 
 minetest.register_craft({
 	output = 'inventorybags:item_filter',
 	recipe = {
-		{'default:steel_ingot', 'group:stick', 'default:steel_ingot'},
+		{items.steel_ingot[inventory_bags.game], 'group:stick', items.steel_ingot[inventory_bags.game]},
 		{'group:stick', 'inventorybags:fabric', 'group:stick'},
-		{'default:steel_ingot', 'group:stick', 'default:steel_ingot'},
+		{items.steel_ingot[inventory_bags.game], 'group:stick', items.steel_ingot[inventory_bags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:item_puller',
 	recipe = {
-		{'default:steel_ingot', 'default:gold_ingot', 'default:steel_ingot'},
-		{'default:obsidian_glass', 'inventorybags:item_filter', 'default:obsidian_glass'},
-		{'default:obsidian_glass', '', 'default:obsidian_glass'},
+		{items.steel_ingot[inventory_bags.game], items.gold_ingot[inventory_bags.game], items.steel_ingot[inventory_bags.game]},
+		{items.obsidian_glass[inventory_bags.game], 'inventorybags:item_filter', items.obsidian_glass[inventory_bags.game]},
+		{items.obsidian_glass[inventory_bags.game], '', items.obsidian_glass[inventory_bags.game]},
 	}
 })
 
@@ -22,7 +57,7 @@ minetest.register_craft({
 	output = 'inventorybags:inventory_connecter',
 	recipe = {
 		{'inventorybags:fabric', 'inventorybags:fabric', 'inventorybags:fabric'},
-		{'inventorybags:item_puller', 'default:mese_crystal', 'inventorybags:item_puller'},
+		{'inventorybags:item_puller', items.mese_crystal[inventory_bags.game], 'inventorybags:item_puller'},
 		{'inventorybags:fabric', 'inventorybags:fabric', 'inventorybags:fabric'},
 	}
 })
@@ -50,7 +85,7 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'inventorybags:bud',
 	recipe = {
-		{'group:stick', 'default:meselamp', ''},
+		{'group:stick', items.mese_lamp[inventory_bags.game], ''},
 		{'group:stick', 'inventorybags:upgrade_base', ''},
 		{'group:wood', 'group:wood', 'group:wood'},
 	}
@@ -62,7 +97,7 @@ minetest.register_craft({
 	output = 'inventorybags:upgrade_base',
 	recipe = {
 		{'inventorybags:yarn', 'group:stick', 'inventorybags:yarn'},
-		{'group:stick', 'default:mese_crystal_fragment', 'group:stick'},
+		{'group:stick', items.mese_crystal_fragment[inventory_bags.game], 'group:stick'},
 		{'inventorybags:yarn', 'group:stick', 'inventorybags:yarn'},
 	}
 })
@@ -70,19 +105,19 @@ minetest.register_craft({
 minetest.register_craft({
 	type = "shapeless",
 	output = "inventorybags:rename_upgrade",
-	recipe = {"inventorybags:upgrade_base", "default:paper"},
+	recipe = {"inventorybags:upgrade_base", items.paper[inventory_bags.game]},
 })
 
 minetest.register_craft({
 	type = "shapeless",
 	output = "inventorybags:coloring_upgrade",
-	recipe = {"inventorybags:upgrade_base", "dye:cyan", "dye:magenta", "dye:yellow", "dye:black", "dye:white"},
+	recipe = {"inventorybags:upgrade_base", items.cyan_dye[inventory_bags.game], items.magenta_dye[inventory_bags.game], items.yellow_dye[inventory_bags.game], items.black_dye[inventory_bags.game], items.white_dye[inventory_bags.game]},
 })
 
 minetest.register_craft({
 	type = "shapeless",
 	output = "inventorybags:coloring_upgrade",
-	recipe = {"inventorybags:upgrade_base", "dye:red", "dye:green", "dye:blue", "dye:black", "dye:white"},
+	recipe = {"inventorybags:upgrade_base", items.red_dye[inventory_bags.game], items.green_dye[inventory_bags.game], items.blue_dye[inventory_bags.game], items.black_dye[inventory_bags.game], items.white_dye[inventory_bags.game]},
 })
 
 if minetest.get_modpath("node_texture_modifier") then
@@ -96,18 +131,18 @@ end
 minetest.register_craft({
 	output = 'inventorybags:collecting_upgrade',
 	recipe = {
-		{'default:steel_ingot', 'inventorybags:upgrade_base', 'default:steel_ingot'},
-		{'default:steel_ingot', 'inventorybags:item_puller', 'default:steel_ingot'},
-		{'default:obsidian_glass', '', 'default:obsidian_glass'},
+		{items.steel_ingot[inventory_bags.game], 'inventorybags:upgrade_base', items.steel_ingot[inventory_bags.game]},
+		{items.steel_ingot[inventory_bags.game], 'inventorybags:item_puller', items.steel_ingot[inventory_bags.game]},
+		{items.obsidian_glass[inventory_bags.game], '', items.obsidian_glass[inventory_bags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:advanced_collecting_upgrade',
 	recipe = {
-		{'default:steel_ingot', 'inventorybags:collecting_upgrade', 'default:steel_ingot'},
-		{'default:steel_ingot', 'inventorybags:item_puller', 'default:steel_ingot'},
-		{'default:obsidian_glass', '', 'default:obsidian_glass'},
+		{items.steel_ingot[inventory_bags.game], 'inventorybags:collecting_upgrade', items.steel_ingot[inventory_bags.game]},
+		{items.steel_ingot[inventory_bags.game], 'inventorybags:item_puller', items.steel_ingot[inventory_bags.game]},
+		{items.obsidian_glass[inventory_bags.game], '', items.obsidian_glass[inventory_bags.game]},
 	}
 })
 
@@ -115,7 +150,7 @@ minetest.register_craft({
 	output = 'inventorybags:sorting_upgrade',
 	recipe = {
 		{'', 'inventorybags:upgrade_base', ''},
-		{'default:ladder_steel', 'default:ladder_steel', 'default:ladder_steel'},
+		{items.steel_ladder[inventory_bags.game], items.steel_ladder[inventory_bags.game], items.steel_ladder[inventory_bags.game]},
 		{'group:wool', 'inventorybags:item_filter', 'group:wool'},
 	}
 })
@@ -124,8 +159,8 @@ minetest.register_craft({
 	output = 'inventorybags:autocrafting_upgrade',
 	recipe = {
 		{'group:wood', 'group:wood', 'group:wood'},
-		{'default:steel_ingot', 'default:mese_crystal', 'default:steel_ingot'},
-		{'default:steel_ingot', 'inventorybags:upgrade_base', 'default:steel_ingot'},
+		{items.steel_ingot[inventory_bags.game], items.mese_crystal[inventory_bags.game], items.steel_ingot[inventory_bags.game]},
+		{items.steel_ingot[inventory_bags.game], 'inventorybags:upgrade_base', items.steel_ingot[inventory_bags.game]},
 	}
 })
 
@@ -141,8 +176,8 @@ end
 minetest.register_craft({
 	output = 'inventorybags:dumping_upgrade',
 	recipe = {
-		{'default:steel_ingot', 'inventorybags:upgrade_base', 'default:steel_ingot'},
-		{'default:steel_ingot', 'inventorybags:item_puller', 'default:steel_ingot'},
+		{items.steel_ingot[inventory_bags.game], 'inventorybags:upgrade_base', items.steel_ingot[inventory_bags.game]},
+		{items.steel_ingot[inventory_bags.game], 'inventorybags:item_puller', items.steel_ingot[inventory_bags.game]},
 		{'group:stone', 'bucket:bucket_lava', 'group:stone'},
 	},
 	replacements = {{"bucket:bucket_lava", "bucket:bucket_empty"}},
@@ -165,61 +200,61 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'inventorybags:opening_sound_upgrade',
 	recipe = {
-		{'', '', 'default:steel_ingot'},
-		{'inventorybags:upgrade_base', 'default:steel_ingot', 'default:paper'},
-		{'', '', 'default:steel_ingot'},
+		{'', '', items.steel_ingot[inventory_bags.game]},
+		{'inventorybags:upgrade_base', items.steel_ingot[inventory_bags.game], items.paper[inventory_bags.game]},
+		{'', '', items.steel_ingot[inventory_bags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:refilling_upgrade',
 	recipe = {
-		{'default:bronze_ingot', 'inventorybags:item_puller', 'default:bronze_ingot'},
-		{'default:bronze_ingot', 'inventorybags:upgrade_base', 'default:bronze_ingot'},
+		{items.bronze_ingot[inventory_bags.game], 'inventorybags:item_puller', items.bronze_ingot[inventory_bags.game]},
+		{items.bronze_ingot[inventory_bags.game], 'inventorybags:upgrade_base', items.bronze_ingot[inventory_bags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:closing_sound_upgrade',
 	recipe = {
-		{'default:steel_ingot', '', ''},
-		{'default:paper', 'default:steel_ingot', 'inventorybags:upgrade_base'},
-		{'default:steel_ingot', '', ''},
+		{items.steel_ingot[inventory_bags.game], '', ''},
+		{items.paper[inventory_bags.game], items.steel_ingot[inventory_bags.game], 'inventorybags:upgrade_base'},
+		{items.steel_ingot[inventory_bags.game], '', ''},
 	}
 })
 
-if minetest.registered_items["inventorybags:explosion_upgrade"] then
+if minetest.registered_items["inventorybags:explosion_upgrade"] or inventory_bags.game == "mcl" then
 	minetest.register_craft({
 		type = "shapeless",
 		output = 'inventorybags:explosion_upgrade',
-		recipe = {"inventorybags:upgrade_base", "tnt:gunpowder", "tnt:tnt"},
+		recipe = {"inventorybags:upgrade_base", items.gunpowder[inventory_bags.game], items.tnt[inventory_bags.game]},
 	})
 end
 
 minetest.register_craft({
 	output = 'inventorybags:storage_upgrade_tier_1',
 	recipe = {
-		{'default:steelblock', 'inventorybags:large_pouch', 'default:steelblock'},
+		{items.steel_block[inventory_bags.game], 'inventorybags:large_pouch', items.steel_block[inventory_bags.game]},
 		{'inventorybags:large_pouch', 'inventorybags:upgrade_base', 'inventorybags:large_pouch'},
-		{'default:steelblock', 'inventorybags:large_pouch', 'default:steelblock'},
+		{items.steel_block[inventory_bags.game], 'inventorybags:large_pouch', items.steel_block[inventory_bags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:storage_upgrade_tier_2',
 	recipe = {
-		{'default:goldblock', 'inventorybags:large_pouch', 'default:goldblock'},
+		{items.gold_block[inventory_bags.game], 'inventorybags:large_pouch', items.gold_block[inventory_bags.game]},
 		{'inventorybags:large_pouch', 'inventorybags:storage_upgrade_tier_1', 'inventorybags:large_pouch'},
-		{'default:goldblock', 'inventorybags:large_pouch', 'default:goldblock'},
+		{items.gold_block[inventory_bags.game], 'inventorybags:large_pouch', items.gold_block[inventory_bags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:storage_upgrade_tier_3',
 	recipe = {
-		{'default:diamondblock', 'inventorybags:large_pouch', 'default:diamondblock'},
+		{items.diamond_block[inventory_bags.game], 'inventorybags:large_pouch', items.diamond_block[inventory_bags.game]},
 		{'inventorybags:large_pouch', 'inventorybags:storage_upgrade_tier_2', 'inventorybags:large_pouch'},
-		{'default:diamondblock', 'inventorybags:large_pouch', 'default:diamondblock'},
+		{items.diamond_block[inventory_bags.game], 'inventorybags:large_pouch', items.diamond_block[inventory_bags.game]},
 	}
 })
 
@@ -285,9 +320,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'inventorybags:suitcase',
 	recipe = {
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{items.steel_ingot[inventory_bags.game], items.steel_ingot[inventory_bags.game], items.steel_ingot[inventory_bags.game]},
 		{'inventorybags:large_pouch', 'inventorybags:fabric', 'inventorybags:large_pouch'},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{items.steel_ingot[inventory_bags.game], items.steel_ingot[inventory_bags.game], items.steel_ingot[inventory_bags.game]},
 	},
 })
 
@@ -323,7 +358,7 @@ minetest.register_craft({
 	recipe = {
 		{'inventorybags:yarn', '', 'inventorybags:yarn'},
 		{'group:wood', 'group:wood', 'group:wood'},
-		{'inventorybags:large_pouch', 'default:chest', 'inventorybags:large_pouch'},
+		{'inventorybags:large_pouch', items.chest[inventory_bags.game], 'inventorybags:large_pouch'},
 	},
 })
 
@@ -339,9 +374,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'inventorybags:paper_bag',
 	recipe = {
-		{'default:paper', '', 'default:paper'},
-		{'default:paper', 'default:paper', 'default:paper'},
-		{'default:paper', 'default:paper', 'default:paper'},
+		{items.paper[inventory_bags.game], '', items.paper[inventory_bags.game]},
+		{items.paper[inventory_bags.game], items.paper[inventory_bags.game], items.paper[inventory_bags.game]},
+		{items.paper[inventory_bags.game], items.paper[inventory_bags.game], items.paper[inventory_bags.game]},
 	},
 })
 
@@ -366,13 +401,13 @@ minetest.register_craft({
 	},
 })
 
-if minetest.setting_getbool("inventorybags_enable_item_teleportation_bag") then
+if minetest.settings:get_bool("inventorybags_enable_item_teleportation_bag", false) then
 	minetest.register_craft({
 		output = 'inventorybags:item_teleportation_bag',
 		recipe = {
-			{'default:diamond', 'inventorybags:large_pouch', 'default:diamond'},
-			{'default:diamond', 'inventorybags:inventory_connecter', 'default:diamond'},
-			{'default:diamond', 'default:mese', 'default:diamond'},
+			{items.diamond[inventory_bags.game], 'inventorybags:large_pouch', items.diamond[inventory_bags.game]},
+			{items.diamond[inventory_bags.game], 'inventorybags:inventory_connecter', items.diamond[inventory_bags.game]},
+			{items.diamond[inventory_bags.game], items.mese_block[inventory_bags.game], items.diamond[inventory_bags.game]},
 		},
 	})
 	if minetest.get_modpath("pipeworks") then
@@ -384,11 +419,11 @@ if minetest.setting_getbool("inventorybags_enable_item_teleportation_bag") then
 	end
 end
 
-if minetest.get_modpath("xdecor") then
+if minetest.get_modpath("xdecor") or inventory_bags.game == "mcl" then
 	minetest.register_craft({
 		type = "shapeless",
 		output = 'inventorybags:ender_bag',
-		recipe = {"inventorybags:large_pouch", "inventorybags:inventory_connecter", "xdecor:enderchest"},
+		recipe = {"inventorybags:large_pouch", "inventorybags:inventory_connecter", items.ender_chest[inventory_bags.game]},
 	})
 end
 
@@ -400,11 +435,11 @@ if minetest.get_modpath("more_chests") then
 	})
 end
 
-if minetest.get_modpath("beds") then
+if minetest.get_modpath("beds") or inventory_bags.game == "mcl" then
 	minetest.register_craft({
 		output = 'inventorybags:sleeping_bag',
 		recipe = {
-			{"wool:red", "wool:red", "wool:white"},
+			{items.red_wool[inventory_bags.game], items.red_wool[inventory_bags.game], items.white_wool[inventory_bags.game]},
 			{"", "inventorybags:large_pouch", ""}
 		},
 	})
@@ -415,13 +450,13 @@ if minetest.get_modpath("beds") then
 		recipe = {"inventorybags:large_pouch", "group:bed"},
 	})
 end
-if not minetest.setting_getbool("inventorybags_dialable_bag_of_winds") then
+if not minetest.settings:get_bool("inventorybags_disable_bag_of_winds", false) and inventory_bags.game ~= "mcl" then
 	minetest.register_craft({
 		output = 'inventorybags:bag_of_winds_closed',
 		recipe = {
-			{"default:goldblock", "inventorybags:large_pouch", "default:goldblock"},
-			{"default:diamondblock", "default:mese", "default:diamondblock"},
-			{"default:diamondblock", "default:mese", "default:diamondblock"}
+			{items.gold_block[inventory_bags.game], "inventorybags:large_pouch", items.gold_block[inventory_bags.game]},
+			{items.diamond_block[inventory_bags.game], items.mese_block[inventory_bags.game], items.diamond_block[inventory_bags.game]},
+			{items.diamond_block[inventory_bags.game], items.mese_block[inventory_bags.game], items.diamond_block[inventory_bags.game]}
 		},
 	})
 end

--- a/crafting.lua
+++ b/crafting.lua
@@ -1,4 +1,4 @@
-minetest.log(inventory_bags.game)
+minetest.log(inventorybags.game)
 
 local items = {
 	steel_ingot = {mtg = "default:steel_ingot", mcl = "mcl_core:iron_ingot"},
@@ -38,18 +38,18 @@ local items = {
 minetest.register_craft({
 	output = 'inventorybags:item_filter',
 	recipe = {
-		{items.steel_ingot[inventory_bags.game], 'group:stick', items.steel_ingot[inventory_bags.game]},
+		{items.steel_ingot[inventorybags.game], 'group:stick', items.steel_ingot[inventorybags.game]},
 		{'group:stick', 'inventorybags:fabric', 'group:stick'},
-		{items.steel_ingot[inventory_bags.game], 'group:stick', items.steel_ingot[inventory_bags.game]},
+		{items.steel_ingot[inventorybags.game], 'group:stick', items.steel_ingot[inventorybags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:item_puller',
 	recipe = {
-		{items.steel_ingot[inventory_bags.game], items.gold_ingot[inventory_bags.game], items.steel_ingot[inventory_bags.game]},
-		{items.obsidian_glass[inventory_bags.game], 'inventorybags:item_filter', items.obsidian_glass[inventory_bags.game]},
-		{items.obsidian_glass[inventory_bags.game], '', items.obsidian_glass[inventory_bags.game]},
+		{items.steel_ingot[inventorybags.game], items.gold_ingot[inventorybags.game], items.steel_ingot[inventorybags.game]},
+		{items.obsidian_glass[inventorybags.game], 'inventorybags:item_filter', items.obsidian_glass[inventorybags.game]},
+		{items.obsidian_glass[inventorybags.game], '', items.obsidian_glass[inventorybags.game]},
 	}
 })
 
@@ -57,7 +57,7 @@ minetest.register_craft({
 	output = 'inventorybags:inventory_connecter',
 	recipe = {
 		{'inventorybags:fabric', 'inventorybags:fabric', 'inventorybags:fabric'},
-		{'inventorybags:item_puller', items.mese_crystal[inventory_bags.game], 'inventorybags:item_puller'},
+		{'inventorybags:item_puller', items.mese_crystal[inventorybags.game], 'inventorybags:item_puller'},
 		{'inventorybags:fabric', 'inventorybags:fabric', 'inventorybags:fabric'},
 	}
 })
@@ -85,7 +85,7 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'inventorybags:bud',
 	recipe = {
-		{'group:stick', items.mese_lamp[inventory_bags.game], ''},
+		{'group:stick', items.mese_lamp[inventorybags.game], ''},
 		{'group:stick', 'inventorybags:upgrade_base', ''},
 		{'group:wood', 'group:wood', 'group:wood'},
 	}
@@ -97,7 +97,7 @@ minetest.register_craft({
 	output = 'inventorybags:upgrade_base',
 	recipe = {
 		{'inventorybags:yarn', 'group:stick', 'inventorybags:yarn'},
-		{'group:stick', items.mese_crystal_fragment[inventory_bags.game], 'group:stick'},
+		{'group:stick', items.mese_crystal_fragment[inventorybags.game], 'group:stick'},
 		{'inventorybags:yarn', 'group:stick', 'inventorybags:yarn'},
 	}
 })
@@ -105,19 +105,19 @@ minetest.register_craft({
 minetest.register_craft({
 	type = "shapeless",
 	output = "inventorybags:rename_upgrade",
-	recipe = {"inventorybags:upgrade_base", items.paper[inventory_bags.game]},
+	recipe = {"inventorybags:upgrade_base", items.paper[inventorybags.game]},
 })
 
 minetest.register_craft({
 	type = "shapeless",
 	output = "inventorybags:coloring_upgrade",
-	recipe = {"inventorybags:upgrade_base", items.cyan_dye[inventory_bags.game], items.magenta_dye[inventory_bags.game], items.yellow_dye[inventory_bags.game], items.black_dye[inventory_bags.game], items.white_dye[inventory_bags.game]},
+	recipe = {"inventorybags:upgrade_base", items.cyan_dye[inventorybags.game], items.magenta_dye[inventorybags.game], items.yellow_dye[inventorybags.game], items.black_dye[inventorybags.game], items.white_dye[inventorybags.game]},
 })
 
 minetest.register_craft({
 	type = "shapeless",
 	output = "inventorybags:coloring_upgrade",
-	recipe = {"inventorybags:upgrade_base", items.red_dye[inventory_bags.game], items.green_dye[inventory_bags.game], items.blue_dye[inventory_bags.game], items.black_dye[inventory_bags.game], items.white_dye[inventory_bags.game]},
+	recipe = {"inventorybags:upgrade_base", items.red_dye[inventorybags.game], items.green_dye[inventorybags.game], items.blue_dye[inventorybags.game], items.black_dye[inventorybags.game], items.white_dye[inventorybags.game]},
 })
 
 if minetest.get_modpath("node_texture_modifier") then
@@ -131,18 +131,18 @@ end
 minetest.register_craft({
 	output = 'inventorybags:collecting_upgrade',
 	recipe = {
-		{items.steel_ingot[inventory_bags.game], 'inventorybags:upgrade_base', items.steel_ingot[inventory_bags.game]},
-		{items.steel_ingot[inventory_bags.game], 'inventorybags:item_puller', items.steel_ingot[inventory_bags.game]},
-		{items.obsidian_glass[inventory_bags.game], '', items.obsidian_glass[inventory_bags.game]},
+		{items.steel_ingot[inventorybags.game], 'inventorybags:upgrade_base', items.steel_ingot[inventorybags.game]},
+		{items.steel_ingot[inventorybags.game], 'inventorybags:item_puller', items.steel_ingot[inventorybags.game]},
+		{items.obsidian_glass[inventorybags.game], '', items.obsidian_glass[inventorybags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:advanced_collecting_upgrade',
 	recipe = {
-		{items.steel_ingot[inventory_bags.game], 'inventorybags:collecting_upgrade', items.steel_ingot[inventory_bags.game]},
-		{items.steel_ingot[inventory_bags.game], 'inventorybags:item_puller', items.steel_ingot[inventory_bags.game]},
-		{items.obsidian_glass[inventory_bags.game], '', items.obsidian_glass[inventory_bags.game]},
+		{items.steel_ingot[inventorybags.game], 'inventorybags:collecting_upgrade', items.steel_ingot[inventorybags.game]},
+		{items.steel_ingot[inventorybags.game], 'inventorybags:item_puller', items.steel_ingot[inventorybags.game]},
+		{items.obsidian_glass[inventorybags.game], '', items.obsidian_glass[inventorybags.game]},
 	}
 })
 
@@ -150,7 +150,7 @@ minetest.register_craft({
 	output = 'inventorybags:sorting_upgrade',
 	recipe = {
 		{'', 'inventorybags:upgrade_base', ''},
-		{items.steel_ladder[inventory_bags.game], items.steel_ladder[inventory_bags.game], items.steel_ladder[inventory_bags.game]},
+		{items.steel_ladder[inventorybags.game], items.steel_ladder[inventorybags.game], items.steel_ladder[inventorybags.game]},
 		{'group:wool', 'inventorybags:item_filter', 'group:wool'},
 	}
 })
@@ -159,8 +159,8 @@ minetest.register_craft({
 	output = 'inventorybags:autocrafting_upgrade',
 	recipe = {
 		{'group:wood', 'group:wood', 'group:wood'},
-		{items.steel_ingot[inventory_bags.game], items.mese_crystal[inventory_bags.game], items.steel_ingot[inventory_bags.game]},
-		{items.steel_ingot[inventory_bags.game], 'inventorybags:upgrade_base', items.steel_ingot[inventory_bags.game]},
+		{items.steel_ingot[inventorybags.game], items.mese_crystal[inventorybags.game], items.steel_ingot[inventorybags.game]},
+		{items.steel_ingot[inventorybags.game], 'inventorybags:upgrade_base', items.steel_ingot[inventorybags.game]},
 	}
 })
 
@@ -176,8 +176,8 @@ end
 minetest.register_craft({
 	output = 'inventorybags:dumping_upgrade',
 	recipe = {
-		{items.steel_ingot[inventory_bags.game], 'inventorybags:upgrade_base', items.steel_ingot[inventory_bags.game]},
-		{items.steel_ingot[inventory_bags.game], 'inventorybags:item_puller', items.steel_ingot[inventory_bags.game]},
+		{items.steel_ingot[inventorybags.game], 'inventorybags:upgrade_base', items.steel_ingot[inventorybags.game]},
+		{items.steel_ingot[inventorybags.game], 'inventorybags:item_puller', items.steel_ingot[inventorybags.game]},
 		{'group:stone', 'bucket:bucket_lava', 'group:stone'},
 	},
 	replacements = {{"bucket:bucket_lava", "bucket:bucket_empty"}},
@@ -200,61 +200,61 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'inventorybags:opening_sound_upgrade',
 	recipe = {
-		{'', '', items.steel_ingot[inventory_bags.game]},
-		{'inventorybags:upgrade_base', items.steel_ingot[inventory_bags.game], items.paper[inventory_bags.game]},
-		{'', '', items.steel_ingot[inventory_bags.game]},
+		{'', '', items.steel_ingot[inventorybags.game]},
+		{'inventorybags:upgrade_base', items.steel_ingot[inventorybags.game], items.paper[inventorybags.game]},
+		{'', '', items.steel_ingot[inventorybags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:refilling_upgrade',
 	recipe = {
-		{items.bronze_ingot[inventory_bags.game], 'inventorybags:item_puller', items.bronze_ingot[inventory_bags.game]},
-		{items.bronze_ingot[inventory_bags.game], 'inventorybags:upgrade_base', items.bronze_ingot[inventory_bags.game]},
+		{items.bronze_ingot[inventorybags.game], 'inventorybags:item_puller', items.bronze_ingot[inventorybags.game]},
+		{items.bronze_ingot[inventorybags.game], 'inventorybags:upgrade_base', items.bronze_ingot[inventorybags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:closing_sound_upgrade',
 	recipe = {
-		{items.steel_ingot[inventory_bags.game], '', ''},
-		{items.paper[inventory_bags.game], items.steel_ingot[inventory_bags.game], 'inventorybags:upgrade_base'},
-		{items.steel_ingot[inventory_bags.game], '', ''},
+		{items.steel_ingot[inventorybags.game], '', ''},
+		{items.paper[inventorybags.game], items.steel_ingot[inventorybags.game], 'inventorybags:upgrade_base'},
+		{items.steel_ingot[inventorybags.game], '', ''},
 	}
 })
 
-if minetest.registered_items["inventorybags:explosion_upgrade"] or inventory_bags.game == "mcl" then
+if minetest.registered_items["inventorybags:explosion_upgrade"] or inventorybags.game == "mcl" then
 	minetest.register_craft({
 		type = "shapeless",
 		output = 'inventorybags:explosion_upgrade',
-		recipe = {"inventorybags:upgrade_base", items.gunpowder[inventory_bags.game], items.tnt[inventory_bags.game]},
+		recipe = {"inventorybags:upgrade_base", items.gunpowder[inventorybags.game], items.tnt[inventorybags.game]},
 	})
 end
 
 minetest.register_craft({
 	output = 'inventorybags:storage_upgrade_tier_1',
 	recipe = {
-		{items.steel_block[inventory_bags.game], 'inventorybags:large_pouch', items.steel_block[inventory_bags.game]},
+		{items.steel_block[inventorybags.game], 'inventorybags:large_pouch', items.steel_block[inventorybags.game]},
 		{'inventorybags:large_pouch', 'inventorybags:upgrade_base', 'inventorybags:large_pouch'},
-		{items.steel_block[inventory_bags.game], 'inventorybags:large_pouch', items.steel_block[inventory_bags.game]},
+		{items.steel_block[inventorybags.game], 'inventorybags:large_pouch', items.steel_block[inventorybags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:storage_upgrade_tier_2',
 	recipe = {
-		{items.gold_block[inventory_bags.game], 'inventorybags:large_pouch', items.gold_block[inventory_bags.game]},
+		{items.gold_block[inventorybags.game], 'inventorybags:large_pouch', items.gold_block[inventorybags.game]},
 		{'inventorybags:large_pouch', 'inventorybags:storage_upgrade_tier_1', 'inventorybags:large_pouch'},
-		{items.gold_block[inventory_bags.game], 'inventorybags:large_pouch', items.gold_block[inventory_bags.game]},
+		{items.gold_block[inventorybags.game], 'inventorybags:large_pouch', items.gold_block[inventorybags.game]},
 	}
 })
 
 minetest.register_craft({
 	output = 'inventorybags:storage_upgrade_tier_3',
 	recipe = {
-		{items.diamond_block[inventory_bags.game], 'inventorybags:large_pouch', items.diamond_block[inventory_bags.game]},
+		{items.diamond_block[inventorybags.game], 'inventorybags:large_pouch', items.diamond_block[inventorybags.game]},
 		{'inventorybags:large_pouch', 'inventorybags:storage_upgrade_tier_2', 'inventorybags:large_pouch'},
-		{items.diamond_block[inventory_bags.game], 'inventorybags:large_pouch', items.diamond_block[inventory_bags.game]},
+		{items.diamond_block[inventorybags.game], 'inventorybags:large_pouch', items.diamond_block[inventorybags.game]},
 	}
 })
 
@@ -320,9 +320,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'inventorybags:suitcase',
 	recipe = {
-		{items.steel_ingot[inventory_bags.game], items.steel_ingot[inventory_bags.game], items.steel_ingot[inventory_bags.game]},
+		{items.steel_ingot[inventorybags.game], items.steel_ingot[inventorybags.game], items.steel_ingot[inventorybags.game]},
 		{'inventorybags:large_pouch', 'inventorybags:fabric', 'inventorybags:large_pouch'},
-		{items.steel_ingot[inventory_bags.game], items.steel_ingot[inventory_bags.game], items.steel_ingot[inventory_bags.game]},
+		{items.steel_ingot[inventorybags.game], items.steel_ingot[inventorybags.game], items.steel_ingot[inventorybags.game]},
 	},
 })
 
@@ -358,7 +358,7 @@ minetest.register_craft({
 	recipe = {
 		{'inventorybags:yarn', '', 'inventorybags:yarn'},
 		{'group:wood', 'group:wood', 'group:wood'},
-		{'inventorybags:large_pouch', items.chest[inventory_bags.game], 'inventorybags:large_pouch'},
+		{'inventorybags:large_pouch', items.chest[inventorybags.game], 'inventorybags:large_pouch'},
 	},
 })
 
@@ -374,9 +374,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'inventorybags:paper_bag',
 	recipe = {
-		{items.paper[inventory_bags.game], '', items.paper[inventory_bags.game]},
-		{items.paper[inventory_bags.game], items.paper[inventory_bags.game], items.paper[inventory_bags.game]},
-		{items.paper[inventory_bags.game], items.paper[inventory_bags.game], items.paper[inventory_bags.game]},
+		{items.paper[inventorybags.game], '', items.paper[inventorybags.game]},
+		{items.paper[inventorybags.game], items.paper[inventorybags.game], items.paper[inventorybags.game]},
+		{items.paper[inventorybags.game], items.paper[inventorybags.game], items.paper[inventorybags.game]},
 	},
 })
 
@@ -405,9 +405,9 @@ if minetest.settings:get_bool("inventorybags_enable_item_teleportation_bag", fal
 	minetest.register_craft({
 		output = 'inventorybags:item_teleportation_bag',
 		recipe = {
-			{items.diamond[inventory_bags.game], 'inventorybags:large_pouch', items.diamond[inventory_bags.game]},
-			{items.diamond[inventory_bags.game], 'inventorybags:inventory_connecter', items.diamond[inventory_bags.game]},
-			{items.diamond[inventory_bags.game], items.mese_block[inventory_bags.game], items.diamond[inventory_bags.game]},
+			{items.diamond[inventorybags.game], 'inventorybags:large_pouch', items.diamond[inventorybags.game]},
+			{items.diamond[inventorybags.game], 'inventorybags:inventory_connecter', items.diamond[inventorybags.game]},
+			{items.diamond[inventorybags.game], items.mese_block[inventorybags.game], items.diamond[inventorybags.game]},
 		},
 	})
 	if minetest.get_modpath("pipeworks") then
@@ -419,11 +419,11 @@ if minetest.settings:get_bool("inventorybags_enable_item_teleportation_bag", fal
 	end
 end
 
-if minetest.get_modpath("xdecor") or inventory_bags.game == "mcl" then
+if minetest.get_modpath("xdecor") or inventorybags.game == "mcl" then
 	minetest.register_craft({
 		type = "shapeless",
 		output = 'inventorybags:ender_bag',
-		recipe = {"inventorybags:large_pouch", "inventorybags:inventory_connecter", items.ender_chest[inventory_bags.game]},
+		recipe = {"inventorybags:large_pouch", "inventorybags:inventory_connecter", items.ender_chest[inventorybags.game]},
 	})
 end
 
@@ -435,11 +435,11 @@ if minetest.get_modpath("more_chests") then
 	})
 end
 
-if minetest.get_modpath("beds") or inventory_bags.game == "mcl" then
+if minetest.get_modpath("beds") or inventorybags.game == "mcl" then
 	minetest.register_craft({
 		output = 'inventorybags:sleeping_bag',
 		recipe = {
-			{items.red_wool[inventory_bags.game], items.red_wool[inventory_bags.game], items.white_wool[inventory_bags.game]},
+			{items.red_wool[inventorybags.game], items.red_wool[inventorybags.game], items.white_wool[inventorybags.game]},
 			{"", "inventorybags:large_pouch", ""}
 		},
 	})
@@ -450,13 +450,13 @@ if minetest.get_modpath("beds") or inventory_bags.game == "mcl" then
 		recipe = {"inventorybags:large_pouch", "group:bed"},
 	})
 end
-if not minetest.settings:get_bool("inventorybags_disable_bag_of_winds", false) and inventory_bags.game ~= "mcl" then
+if not minetest.settings:get_bool("inventorybags_disable_bag_of_winds", false) and inventorybags.game ~= "mcl" then
 	minetest.register_craft({
 		output = 'inventorybags:bag_of_winds_closed',
 		recipe = {
-			{items.gold_block[inventory_bags.game], "inventorybags:large_pouch", items.gold_block[inventory_bags.game]},
-			{items.diamond_block[inventory_bags.game], items.mese_block[inventory_bags.game], items.diamond_block[inventory_bags.game]},
-			{items.diamond_block[inventory_bags.game], items.mese_block[inventory_bags.game], items.diamond_block[inventory_bags.game]}
+			{items.gold_block[inventorybags.game], "inventorybags:large_pouch", items.gold_block[inventorybags.game]},
+			{items.diamond_block[inventorybags.game], items.mese_block[inventorybags.game], items.diamond_block[inventorybags.game]},
+			{items.diamond_block[inventorybags.game], items.mese_block[inventorybags.game], items.diamond_block[inventorybags.game]}
 		},
 	})
 end

--- a/devices.lua
+++ b/devices.lua
@@ -50,24 +50,28 @@ local function open_spinning_wheel(user)
 	local inv = minetest.get_inventory({type="player", name=playername})
 	inv:set_size(invname.."_in", 1)
 	inv:set_size(invname.."_out", 4)
-		
-	minetest.show_formspec(playername, invname,
-		"size[8,7]" ..
-		default.gui_bg ..
-		default.gui_bg_img ..
-		default.gui_slots ..
-		"list[current_player;"..invname.."_in;1,0.8;1,1;]" ..
-		"item_image[1,0.8;1,1;wool:white]" ..
-		"button[3,0.8;1,1;spin;Spin]" ..
-		"list[current_player;"..invname.."_out;5,0.3;2,2;]" ..
-		"list[current_player;main;0,2.85;8,1;]" ..
-		"list[current_player;main;0,4.08;8,3;8]" ..
-		"listring[current_player;"..invname.."_out]" ..
-		"listring[current_player;main]" ..
-		"listring[current_player;"..invname.."_in]" ..
-		"listring[current_player;main]" ..
-		default.get_hotbar_bg(0,2.85)
-	)
+	local spinning_wheel_formspec = "size["..inventory_bags.width..",7]" ..
+	inventory_bags.gui_bg ..
+	inventory_bags.gui_bg_img ..
+	inventory_bags.gui_slots ..
+	"list[current_player;"..invname.."_in;1,0.8;1,1;]" ..
+	"button[3,0.8;1,1;spin;Spin]" ..
+	"list[current_player;"..invname.."_out;5,0.3;2,2;]"..
+	inventory_bags.inventory_formspec(2.85)
+	if inventory_bags.game == "mtg" then
+		spinning_wheel_formspec = spinning_wheel_formspec.."item_image[1,0.8;1,1;wool:white]"
+	else
+		spinning_wheel_formspec = spinning_wheel_formspec..
+		"item_image[1,0.8;1,1;mcl_wool:white]" ..
+		mcl_formspec.get_itemslot_bg(1,0.8,1,1)..
+		mcl_formspec.get_itemslot_bg(5,0.3,2,2)
+	end
+	spinning_wheel_formspec = spinning_wheel_formspec..
+	"listring[current_player;"..invname.."_out]" ..
+	"listring[current_player;main]" ..
+	"listring[current_player;"..invname.."_in]" ..
+	"listring[current_player;main]"
+	minetest.show_formspec(playername, invname, spinning_wheel_formspec)
 end
 
 minetest.register_craftitem("inventorybags:spinning_wheel", {
@@ -87,25 +91,28 @@ local function open_loom(user)
 	local inv = minetest.get_inventory({type="player", name=playername})
 	inv:set_size(invname.."_in", 2)
 	inv:set_size(invname.."_out", 4)
-	
-	minetest.show_formspec(playername, invname,
-		"size[8,7]" ..
-		default.gui_bg ..
-		default.gui_bg_img ..
-		default.gui_slots ..
-		"list[current_player;"..invname.."_in;1,0.3;1,2;]" ..
-		"item_image[1,0.3;1,1;inventorybags:yarn]" ..
-		"item_image[1,1.3;1,1;inventorybags:yarn]" ..
-		"button[3,0.8;1,1;weave;Weave]" ..
-		"list[current_player;"..invname.."_out;5,0.3;2,2;]" ..
-		"list[current_player;main;0,2.85;8,1;]" ..
-		"list[current_player;main;0,4.08;8,3;8]" ..
-		"listring[current_player;"..invname.."_out]" ..
-		"listring[current_player;main]" ..
-		"listring[current_player;"..invname.."_in]" ..
-		"listring[current_player;main]" ..
-		default.get_hotbar_bg(0,2.85)
-	)
+
+	local loom_formspec = "size["..inventory_bags.width..",7]" ..
+	inventory_bags.gui_bg ..
+	inventory_bags.gui_bg_img ..
+	inventory_bags.gui_slots ..
+	"list[current_player;"..invname.."_in;1,0.3;1,2;]" ..
+	"item_image[1,0.3;1,1;inventorybags:yarn]" ..
+	"item_image[1,1.3;1,1;inventorybags:yarn]" ..
+	"button[3,0.8;1,1;weave;Weave]"..
+	"list[current_player;"..invname.."_out;5,0.3;2,2;]"..
+	inventory_bags.inventory_formspec(2.85)
+	if inventory_bags.game == "mcl" then
+		loom_formspec = loom_formspec..
+		mcl_formspec.get_itemslot_bg(1,0.3,1,2)..
+		mcl_formspec.get_itemslot_bg(5,0.3,2,2)
+	end
+	loom_formspec = loom_formspec..
+	"listring[current_player;"..invname.."_out]" ..
+	"listring[current_player;main]" ..
+	"listring[current_player;"..invname.."_in]" ..
+	"listring[current_player;main]"
+	minetest.show_formspec(playername, invname,	loom_formspec)
 end
 
 minetest.register_craftitem("inventorybags:loom", {
@@ -127,11 +134,10 @@ local function open_bud(user)
 	inv:set_size(invname.."_bag", 1)
 	inv:set_size(invname.."_upgrade", 1)
 	inv:set_size(invname.."_out", 1)
-	minetest.show_formspec(playername, invname,
-		"size[8,7]" ..
-		default.gui_bg ..
-		default.gui_bg_img ..
-		default.gui_slots ..
+	local bud_formspec = "size["..inventory_bags.width..",7]" ..
+		inventory_bags.gui_bg ..
+		inventory_bags.gui_bg_img ..
+		inventory_bags.gui_slots ..
 		"field[0.4,2.2;3.2,0;setting;Setting;"..setting_default.."]" ..
 		"field_close_on_enter[setting;false]" ..
 		"item_image[0.5,0.3;1,1;inventorybags:large_pouch]" ..
@@ -143,17 +149,22 @@ local function open_bud(user)
 		"button[6.3,1.4;1.8,1;recover_setting;Recover Setting]" ..
 		"list[current_player;"..invname.."_bag;0.5,0.3;1,1;]" ..
 		"list[current_player;"..invname.."_upgrade;2,0.3;1,1;]" ..
-		"list[current_player;"..invname.."_out;6.5,0.3;1,1;]" ..
-		"list[current_player;main;0,2.85;8,1;]" ..
-		"list[current_player;main;0,4.08;8,3;8]" ..
-		"listring[current_player;"..invname.."_out]" ..
-		"listring[current_player;main]" ..
-		"listring[current_player;"..invname.."_bag]" ..
-		"listring[current_player;main]" ..
-		"listring[current_player;"..invname.."_upgrade]" ..
-		"listring[current_player;main]" ..
-		default.get_hotbar_bg(0,2.85)
-	)
+		"list[current_player;"..invname.."_out;6.5,0.3;1,1;]"..
+		inventory_bags.inventory_formspec(2.85)
+	if inventory_bags.game == "mcl" then
+		bud_formspec = bud_formspec..
+		mcl_formspec.get_itemslot_bg(0.5,0.3,1,1)..
+		mcl_formspec.get_itemslot_bg(2,0.3,1,1)..
+		mcl_formspec.get_itemslot_bg(6.5,0.3,1,1)
+	end
+	bud_formspec = bud_formspec..
+	"listring[current_player;"..invname.."_out]" ..
+	"listring[current_player;main]" ..
+	"listring[current_player;"..invname.."_bag]" ..
+	"listring[current_player;main]" ..
+	"listring[current_player;"..invname.."_upgrade]" ..
+	"listring[current_player;main]"
+	minetest.show_formspec(playername, invname, bud_formspec)
 end
 
 minetest.register_craftitem("inventorybags:bud", {
@@ -226,10 +237,10 @@ local function show_setting_creator(player, setting_type, extra_table)
 		end
 		local color_list = "textlist[0,0;7.5,2;color_list;"..colorss..";"..extra_table.color_index..";false]"
 		minetest.show_formspec(playername, invname.."_color",
-			"size[8,9]" ..
-			default.gui_bg ..
-			default.gui_bg_img ..
-			default.gui_slots ..
+			"size["..inventory_bags.width..",9]" ..
+			inventory_bags.gui_bg ..
+			inventory_bags.gui_bg_img ..
+			inventory_bags.gui_slots ..
 			"field[0.2,4.3;4.3,0;setting;Setting;"..setting_default.."]" ..
 			"field_close_on_enter[setting;false]" ..
 			"field[0.2,3.1;1.4,0;red;Red (0-255);"..extra_table.red.."]" ..
@@ -244,9 +255,7 @@ local function show_setting_creator(player, setting_type, extra_table)
 			"button[6,3.5;2,1;back;Back and Save]" ..
 			"button[4.2,2.4;1.6,1;set_color;Set Color]" ..
 			"button[6,2.4;2,1;random_color;Random Color]" ..
-			"list[current_player;main;0,4.85;8,1;]" ..
-			"list[current_player;main;0,6.08;8,3;8]" ..
-			default.get_hotbar_bg(0,4.85)
+			inventory_bags.inventory_formspec(4.85)
 		)
 	elseif setting_type == "filter" then
 		local finv = minetest.create_detached_inventory(invname.."_filter", {
@@ -284,33 +293,35 @@ local function show_setting_creator(player, setting_type, extra_table)
 				finv:set_stack("blacklist", i-setting_table.blacklist_counter+1, stack)
 			end
 		end
-		minetest.show_formspec(playername, invname.."_filter",
-			"size[12,11]" ..
-			default.gui_bg ..
-			default.gui_bg_img ..
-			default.gui_slots ..
-			"label[0.2,0.1;Whitelist:          (An empty whitelist doesn't block any item)]"..
-			"label[6.2,0.1;Blacklist:]"..
-			"box[0,0;5.8,5.4;white]" ..
-			"box[6,0;5.8,5.4;black]" ..
-			"box[0.1,0.1;5.6,5.2;black]" ..
-			"box[6.1,0.1;5.6,5.2;#6B6B6B]" ..
-			"label[0.2,0.4;"..minetest.formspec_escape('comma separated lists for example: "moreblocks,default,technic"').."]"..
-			"label[6.2,0.4;"..minetest.formspec_escape('comma separated lists for example: "tree,stone,sand,stick"').."]"..
-			"field[0.5,1.3;5.6,1;group_filter_whitelist;Group Filter:;"..group_filter_whitelist_default.."]" ..
-			"field[0.5,2.3;5.6,1;mod_filter_whitelist;Mod Filter:;"..mod_filter_whitelist_default.."]" ..
-			"field[0.5,3.3;5.6,1;name_filter_whitelist;Name Filter:;"..name_filter_whitelist_default.."]" ..
-			"field[6.5,1.3;5.6,1;group_filter_blacklist;Group Filter:;"..group_filter_blacklist_default.."]" ..
-			"field[6.5,2.3;5.6,1;mod_filter_blacklist;Mod Filter:;"..mod_filter_blacklist_default.."]" ..
-			"field[6.5,3.3;5.6,1;name_filter_blacklist;Name Filter:;"..name_filter_blacklist_default.."]" ..
+		local function colorize(color, string) --just to make it shorter
+			return minetest.formspec_escape(minetest.colorize(color, string))
+		end
+		local filter_formspec = "size[12,11]" ..
+			inventory_bags.gui_bg ..
+			inventory_bags.gui_bg_img ..
+			inventory_bags.gui_slots ..
+			"label[0.2,0.1;"..colorize("#313131", "Whitelist:          (An empty whitelist doesn't block any item)").."]"..
+			"label[6.2,0.1;"..colorize("#eeeeee", "Blacklist:").."]"..
+			"box[0,0;5.8,5.4;#bbbbbb]" ..
+			"box[6,0;5.8,5.4;#333333]" ..
+			"box[0.1,0.1;5.6,5.2;#ffffff]" ..
+			"box[6.1,0.1;5.6,5.2;#111111]" ..
+			"label[0.2,0.4;"..colorize("#313131", 'comma separated lists (e.g. "moreblocks,default,technic")').."]"..
+			"label[6.2,0.4;"..colorize("#eeeeee", 'comma separated lists (e.g. "tree,stone,sand,stick")').."]"..
+			"field[0.5,1.3;5.6,1;group_filter_whitelist;"..colorize("#313131", "Group Filter:")..";"..group_filter_whitelist_default.."]" ..
+			"field[0.5,2.3;5.6,1;mod_filter_whitelist;"..colorize("#313131", "Mod Filter:")..";"..mod_filter_whitelist_default.."]" ..
+			"field[0.5,3.3;5.6,1;name_filter_whitelist;"..colorize("#313131", "Name Filter:")..";"..name_filter_whitelist_default.."]" ..
+			"field[6.5,1.3;5.6,1;group_filter_blacklist;"..colorize("#eeeeee", "Group Filter:")..";"..group_filter_blacklist_default.."]" ..
+			"field[6.5,2.3;5.6,1;mod_filter_blacklist;"..colorize("#eeeeee", "Mod Filter:")..";"..mod_filter_blacklist_default.."]" ..
+			"field[6.5,3.3;5.6,1;name_filter_blacklist;"..colorize("#eeeeee", "Name Filter:")..";"..name_filter_blacklist_default.."]"..
 			"field_close_on_enter[group_filter_whitelist;false]" ..
 			"field_close_on_enter[mod_filter_whitelist;false]" ..
 			"field_close_on_enter[name_filter_whitelist;false]" ..
 			"field_close_on_enter[group_filter_blacklist;false]" ..
 			"field_close_on_enter[mod_filter_blacklist;false]" ..
 			"field_close_on_enter[name_filter_blacklist;false]" ..
-			"label[0.24,3.8;Item Filter:]"..
-			"label[6.24,3.8;Item Filter:]"..
+			"label[0.24,3.8;"..colorize("#313131","Item Filter:").."]"..
+			"label[6.24,3.8;"..colorize("#eeeeee","Item Filter:").."]"..
 			"list[detached:"..invname.."_filter;whitelist;1,4.3;4,1;]" ..
 			"list[detached:"..invname.."_filter;blacklist;7,4.3;4,1;]" ..
 			"listring[detached:"..invname.."_filter;blacklist]" ..
@@ -325,11 +336,14 @@ local function show_setting_creator(player, setting_type, extra_table)
 			"button[11,4.3;0.8,1;next_blacklist;-->]" ..
 			"field[2.2,6.3;6,0;setting;Setting;"..setting_default.."]" ..
 			"field_close_on_enter[setting;false]" ..
-			"button[8,5.5;2,1;back;Back and Save]" ..
-			"list[current_player;main;2,6.85;8,1;]" ..
-			"list[current_player;main;2,8.08;8,3;8]" ..
-			default.get_hotbar_bg(2,6.85)
-		)
+			"button[8,5.5;2,1;back;Back and Save]"..
+			inventory_bags.inventory_formspec(6.85)
+		if inventory_bags.game == "mcl" then
+			filter_formspec = filter_formspec..
+			mcl_formspec.get_itemslot_bg(1,4.3,4,1)..
+			mcl_formspec.get_itemslot_bg(7,4.3,4,1)
+		end
+		minetest.show_formspec(playername, invname.."_filter", filter_formspec)
 	elseif setting_type == "crafting" then
 		local craftinv = minetest.create_detached_inventory(invname.."_crafting", {
 			allow_move = function(inv, from_list, from_index, to_list, to_index, count, player)
@@ -364,11 +378,10 @@ local function show_setting_creator(player, setting_type, extra_table)
 			end
 		end
 		set_crafting_output(craftinv)
-		minetest.show_formspec(playername, invname.."_crafting",
-			"size[8,9]" ..
-			default.gui_bg ..
-			default.gui_bg_img ..
-			default.gui_slots ..
+		local crafting_formspec = "size[8,9]" ..
+			inventory_bags.gui_bg ..
+			inventory_bags.gui_bg_img ..
+			inventory_bags.gui_slots ..
 			"field[0.2,4.3;6,0;setting;Setting;"..setting_default.."]" ..
 			"field_close_on_enter[setting;false]" ..
 			"button[6,3.5;2,1;back;Back and Save]" ..
@@ -383,10 +396,13 @@ local function show_setting_creator(player, setting_type, extra_table)
 			"image[4.5,1.3;1,1;gui_furnace_arrow_bg.png^[transformR270]" ..
 			"list[detached:"..invname.."_crafting;recipe;1.5,0.3;3,3;]" ..
 			"list[detached:"..invname.."_crafting;output;5.5,1.3;1,1;]" ..
-			"list[current_player;main;0,4.85;8,1;]" ..
-			"list[current_player;main;0,6.08;8,3;8]" ..
-			default.get_hotbar_bg(0,4.85)
-		)
+			inventory_bags.inventory_formspec(4.85)
+		if inventory_bags.game == "mcl" then
+			crafting_formspec = crafting_formspec..
+			mcl_formspec.get_itemslot_bg(1.5,0.3,3,3)..
+			mcl_formspec.get_itemslot_bg(5.5,1.3,1,1)
+		end
+		minetest.show_formspec(playername, invname.."_crafting", crafting_formspec)
 	end
 end
 
@@ -509,9 +525,9 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			end
 			minetest.show_formspec(playername, formname.."_help",
 				"size[10,8]" ..
-				default.gui_bg ..
-				default.gui_bg_img ..
-				default.gui_slots ..
+				inventory_bags.gui_bg ..
+				inventory_bags.gui_bg_img ..
+				inventory_bags.gui_slots ..
 				"textlist[0,0;10,8;helptext;".. inventorybags.upgrade_help_string ..";1;true]"
 			)
 		elseif fields.upgrade then

--- a/devices.lua
+++ b/devices.lua
@@ -50,15 +50,15 @@ local function open_spinning_wheel(user)
 	local inv = minetest.get_inventory({type="player", name=playername})
 	inv:set_size(invname.."_in", 1)
 	inv:set_size(invname.."_out", 4)
-	local spinning_wheel_formspec = "size["..inventory_bags.width..",7]" ..
-	inventory_bags.gui_bg ..
-	inventory_bags.gui_bg_img ..
-	inventory_bags.gui_slots ..
+	local spinning_wheel_formspec = "size["..inventorybags.width..",7]" ..
+	inventorybags.gui_bg ..
+	inventorybags.gui_bg_img ..
+	inventorybags.gui_slots ..
 	"list[current_player;"..invname.."_in;1,0.8;1,1;]" ..
 	"button[3,0.8;1,1;spin;Spin]" ..
 	"list[current_player;"..invname.."_out;5,0.3;2,2;]"..
-	inventory_bags.inventory_formspec(2.85)
-	if inventory_bags.game == "mtg" then
+	inventorybags.inventory_formspec(2.85)
+	if inventorybags.game == "mtg" then
 		spinning_wheel_formspec = spinning_wheel_formspec.."item_image[1,0.8;1,1;wool:white]"
 	else
 		spinning_wheel_formspec = spinning_wheel_formspec..
@@ -92,17 +92,17 @@ local function open_loom(user)
 	inv:set_size(invname.."_in", 2)
 	inv:set_size(invname.."_out", 4)
 
-	local loom_formspec = "size["..inventory_bags.width..",7]" ..
-	inventory_bags.gui_bg ..
-	inventory_bags.gui_bg_img ..
-	inventory_bags.gui_slots ..
+	local loom_formspec = "size["..inventorybags.width..",7]" ..
+	inventorybags.gui_bg ..
+	inventorybags.gui_bg_img ..
+	inventorybags.gui_slots ..
 	"list[current_player;"..invname.."_in;1,0.3;1,2;]" ..
 	"item_image[1,0.3;1,1;inventorybags:yarn]" ..
 	"item_image[1,1.3;1,1;inventorybags:yarn]" ..
 	"button[3,0.8;1,1;weave;Weave]"..
 	"list[current_player;"..invname.."_out;5,0.3;2,2;]"..
-	inventory_bags.inventory_formspec(2.85)
-	if inventory_bags.game == "mcl" then
+	inventorybags.inventory_formspec(2.85)
+	if inventorybags.game == "mcl" then
 		loom_formspec = loom_formspec..
 		mcl_formspec.get_itemslot_bg(1,0.3,1,2)..
 		mcl_formspec.get_itemslot_bg(5,0.3,2,2)
@@ -134,10 +134,10 @@ local function open_bud(user)
 	inv:set_size(invname.."_bag", 1)
 	inv:set_size(invname.."_upgrade", 1)
 	inv:set_size(invname.."_out", 1)
-	local bud_formspec = "size["..inventory_bags.width..",7]" ..
-		inventory_bags.gui_bg ..
-		inventory_bags.gui_bg_img ..
-		inventory_bags.gui_slots ..
+	local bud_formspec = "size["..inventorybags.width..",7]" ..
+		inventorybags.gui_bg ..
+		inventorybags.gui_bg_img ..
+		inventorybags.gui_slots ..
 		"field[0.4,2.2;3.2,0;setting;Setting;"..setting_default.."]" ..
 		"field_close_on_enter[setting;false]" ..
 		"item_image[0.5,0.3;1,1;inventorybags:large_pouch]" ..
@@ -150,8 +150,8 @@ local function open_bud(user)
 		"list[current_player;"..invname.."_bag;0.5,0.3;1,1;]" ..
 		"list[current_player;"..invname.."_upgrade;2,0.3;1,1;]" ..
 		"list[current_player;"..invname.."_out;6.5,0.3;1,1;]"..
-		inventory_bags.inventory_formspec(2.85)
-	if inventory_bags.game == "mcl" then
+		inventorybags.inventory_formspec(2.85)
+	if inventorybags.game == "mcl" then
 		bud_formspec = bud_formspec..
 		mcl_formspec.get_itemslot_bg(0.5,0.3,1,1)..
 		mcl_formspec.get_itemslot_bg(2,0.3,1,1)..
@@ -237,10 +237,10 @@ local function show_setting_creator(player, setting_type, extra_table)
 		end
 		local color_list = "textlist[0,0;7.5,2;color_list;"..colorss..";"..extra_table.color_index..";false]"
 		minetest.show_formspec(playername, invname.."_color",
-			"size["..inventory_bags.width..",9]" ..
-			inventory_bags.gui_bg ..
-			inventory_bags.gui_bg_img ..
-			inventory_bags.gui_slots ..
+			"size["..inventorybags.width..",9]" ..
+			inventorybags.gui_bg ..
+			inventorybags.gui_bg_img ..
+			inventorybags.gui_slots ..
 			"field[0.2,4.3;4.3,0;setting;Setting;"..setting_default.."]" ..
 			"field_close_on_enter[setting;false]" ..
 			"field[0.2,3.1;1.4,0;red;Red (0-255);"..extra_table.red.."]" ..
@@ -255,7 +255,7 @@ local function show_setting_creator(player, setting_type, extra_table)
 			"button[6,3.5;2,1;back;Back and Save]" ..
 			"button[4.2,2.4;1.6,1;set_color;Set Color]" ..
 			"button[6,2.4;2,1;random_color;Random Color]" ..
-			inventory_bags.inventory_formspec(4.85)
+			inventorybags.inventory_formspec(4.85)
 		)
 	elseif setting_type == "filter" then
 		local finv = minetest.create_detached_inventory(invname.."_filter", {
@@ -297,9 +297,9 @@ local function show_setting_creator(player, setting_type, extra_table)
 			return minetest.formspec_escape(minetest.colorize(color, string))
 		end
 		local filter_formspec = "size[12,11]" ..
-			inventory_bags.gui_bg ..
-			inventory_bags.gui_bg_img ..
-			inventory_bags.gui_slots ..
+			inventorybags.gui_bg ..
+			inventorybags.gui_bg_img ..
+			inventorybags.gui_slots ..
 			"label[0.2,0.1;"..colorize("#313131", "Whitelist:          (An empty whitelist doesn't block any item)").."]"..
 			"label[6.2,0.1;"..colorize("#eeeeee", "Blacklist:").."]"..
 			"box[0,0;5.8,5.4;#bbbbbb]" ..
@@ -337,8 +337,8 @@ local function show_setting_creator(player, setting_type, extra_table)
 			"field[2.2,6.3;6,0;setting;Setting;"..setting_default.."]" ..
 			"field_close_on_enter[setting;false]" ..
 			"button[8,5.5;2,1;back;Back and Save]"..
-			inventory_bags.inventory_formspec(6.85)
-		if inventory_bags.game == "mcl" then
+			inventorybags.inventory_formspec(6.85)
+		if inventorybags.game == "mcl" then
 			filter_formspec = filter_formspec..
 			mcl_formspec.get_itemslot_bg(1,4.3,4,1)..
 			mcl_formspec.get_itemslot_bg(7,4.3,4,1)
@@ -379,9 +379,9 @@ local function show_setting_creator(player, setting_type, extra_table)
 		end
 		set_crafting_output(craftinv)
 		local crafting_formspec = "size[8,9]" ..
-			inventory_bags.gui_bg ..
-			inventory_bags.gui_bg_img ..
-			inventory_bags.gui_slots ..
+			inventorybags.gui_bg ..
+			inventorybags.gui_bg_img ..
+			inventorybags.gui_slots ..
 			"field[0.2,4.3;6,0;setting;Setting;"..setting_default.."]" ..
 			"field_close_on_enter[setting;false]" ..
 			"button[6,3.5;2,1;back;Back and Save]" ..
@@ -396,8 +396,8 @@ local function show_setting_creator(player, setting_type, extra_table)
 			"image[4.5,1.3;1,1;gui_furnace_arrow_bg.png^[transformR270]" ..
 			"list[detached:"..invname.."_crafting;recipe;1.5,0.3;3,3;]" ..
 			"list[detached:"..invname.."_crafting;output;5.5,1.3;1,1;]" ..
-			inventory_bags.inventory_formspec(4.85)
-		if inventory_bags.game == "mcl" then
+			inventorybags.inventory_formspec(4.85)
+		if inventorybags.game == "mcl" then
 			crafting_formspec = crafting_formspec..
 			mcl_formspec.get_itemslot_bg(1.5,0.3,3,3)..
 			mcl_formspec.get_itemslot_bg(5.5,1.3,1,1)
@@ -525,9 +525,9 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			end
 			minetest.show_formspec(playername, formname.."_help",
 				"size[10,8]" ..
-				inventory_bags.gui_bg ..
-				inventory_bags.gui_bg_img ..
-				inventory_bags.gui_slots ..
+				inventorybags.gui_bg ..
+				inventorybags.gui_bg_img ..
+				inventorybags.gui_slots ..
 				"textlist[0,0;10,8;helptext;".. inventorybags.upgrade_help_string ..";1;true]"
 			)
 		elseif fields.upgrade then

--- a/globaltables.lua
+++ b/globaltables.lua
@@ -1,4 +1,3 @@
-inventorybags = {}
 inventorybags.bud_recipes = {}
 inventorybags.upgrade_help_string = "#ffff00General Info:," ..
 	"Sometimes you have to have opened the bag the first time before the upgrade works.,"..

--- a/init.lua
+++ b/init.lua
@@ -1,15 +1,15 @@
 local modpath = minetest.get_modpath("inventorybags")
 
-inventory_bags = {}
+inventorybags = {}
 if minetest.get_modpath("mcl_core") then
-    inventory_bags.game = "mcl"
-	inventory_bags.gui_bg = mcl_vars.gui_bg_color
-	inventory_bags.gui_bg_img = mcl_vars.gui_bg_img
-	inventory_bags.gui_slots = mcl_vars.gui_slots
-	inventory_bags.get_hotbar_bg = function(x,y)
+    inventorybags.game = "mcl"
+	inventorybags.gui_bg = mcl_vars.gui_bg_color
+	inventorybags.gui_bg_img = mcl_vars.gui_bg_img
+	inventorybags.gui_slots = mcl_vars.gui_slots
+	inventorybags.get_hotbar_bg = function(x,y)
         return mcl_formspec.get_itemslot_bg(x,y,8,1)
     end
-    inventory_bags.width = 9
+    inventorybags.width = 9
 else
     for index, mod in ipairs({"default", "wool", "farming", "stairs", "dye", "bucket"}) do
         if not minetest.get_modpath(mod) then
@@ -17,25 +17,25 @@ else
             "Mod '"..mod.."' not found.")
         end
     end
-    inventory_bags.game = "mtg"
-	inventory_bags.gui_bg = default.gui_bg
-	inventory_bags.gui_bg_img = default.gui_bg_img
-	inventory_bags.gui_slots = default.gui_slots
-	inventory_bags.get_hotbar_bg = default.get_hotbar_bg
-    inventory_bags.width = 8
+    inventorybags.game = "mtg"
+	inventorybags.gui_bg = default.gui_bg
+	inventorybags.gui_bg_img = default.gui_bg_img
+	inventorybags.gui_slots = default.gui_slots
+	inventorybags.get_hotbar_bg = default.get_hotbar_bg
+    inventorybags.width = 8
 end
 
-function inventory_bags.inventory_formspec(y)
+function inventorybags.inventory_formspec(y)
 	local formspec = ""
-	if inventory_bags.game == "mtg" then
-		formspec = "list[current_player;main;0,"..y..";"..inventory_bags.width..",1;]" ..
-		"list[current_player;main;0,"..(y+1.23)..";"..inventory_bags.width..",3;"..inventory_bags.width.."]"..
-		inventory_bags.get_hotbar_bg(0, y)
+	if inventorybags.game == "mtg" then
+		formspec = "list[current_player;main;0,"..y..";"..inventorybags.width..",1;]" ..
+		"list[current_player;main;0,"..(y+1.23)..";"..inventorybags.width..",3;"..inventorybags.width.."]"..
+		inventorybags.get_hotbar_bg(0, y)
 	else
-		formspec = "list[current_player;main;0,"..y..";"..inventory_bags.width..",3;"..inventory_bags.width.."]"..
-		mcl_formspec.get_itemslot_bg(0,y,inventory_bags.width,3)..
-		"list[current_player;main;0,"..(y+3.23)..";"..inventory_bags.width..",1;]"..
-		mcl_formspec.get_itemslot_bg(0,y+3.23,inventory_bags.width,1)
+		formspec = "list[current_player;main;0,"..y..";"..inventorybags.width..",3;"..inventorybags.width.."]"..
+		mcl_formspec.get_itemslot_bg(0,y,inventorybags.width,3)..
+		"list[current_player;main;0,"..(y+3.23)..";"..inventorybags.width..",1;]"..
+		mcl_formspec.get_itemslot_bg(0,y+3.23,inventorybags.width,1)
 	end	
 	return formspec
 end

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,45 @@
 local modpath = minetest.get_modpath("inventorybags")
+
+inventory_bags = {}
+if minetest.get_modpath("mcl_core") then
+    inventory_bags.game = "mcl"
+	inventory_bags.gui_bg = mcl_vars.gui_bg_color
+	inventory_bags.gui_bg_img = mcl_vars.gui_bg_img
+	inventory_bags.gui_slots = mcl_vars.gui_slots
+	inventory_bags.get_hotbar_bg = function(x,y)
+        return mcl_formspec.get_itemslot_bg(x,y,8,1)
+    end
+    inventory_bags.width = 9
+else
+    for index, mod in ipairs({"default", "wool", "farming", "stairs", "dye", "bucket"}) do
+        if not minetest.get_modpath(mod) then
+            error("ERROR: Cannot use inventory bags without either MineClone 2 or the following mods:\n[default, wool, farming, stairs, dye, bucket]"..
+            "Mod '"..mod.."' not found.")
+        end
+    end
+    inventory_bags.game = "mtg"
+	inventory_bags.gui_bg = default.gui_bg
+	inventory_bags.gui_bg_img = default.gui_bg_img
+	inventory_bags.gui_slots = default.gui_slots
+	inventory_bags.get_hotbar_bg = default.get_hotbar_bg
+    inventory_bags.width = 8
+end
+
+function inventory_bags.inventory_formspec(y)
+	local formspec = ""
+	if inventory_bags.game == "mtg" then
+		formspec = "list[current_player;main;0,"..y..";"..inventory_bags.width..",1;]" ..
+		"list[current_player;main;0,"..(y+1.23)..";"..inventory_bags.width..",3;"..inventory_bags.width.."]"..
+		inventory_bags.get_hotbar_bg(0, y)
+	else
+		formspec = "list[current_player;main;0,"..y..";"..inventory_bags.width..",3;"..inventory_bags.width.."]"..
+		mcl_formspec.get_itemslot_bg(0,y,inventory_bags.width,3)..
+		"list[current_player;main;0,"..(y+3.23)..";"..inventory_bags.width..",1;]"..
+		mcl_formspec.get_itemslot_bg(0,y+3.23,inventory_bags.width,1)
+	end	
+	return formspec
+end
+
 dofile(modpath .. "/globaltables.lua")
 dofile(modpath .. "/craftitems.lua")
 dofile(modpath .. "/bags.lua")

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,3 @@
 name = inventorybags
+description = A mod that adds bags.
+optional_depends = unified_inventory, more_chests, xdecor, beds, pipeworks, homedecor, node_texture_modifier, default, wool, farming, stairs, dye, bucket, tnt, mcl_core, mcl_chests

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,5 +1,7 @@
 # Defaut off, because it doesn't work very well
+# Most games do not let you move items to/from containers without being near them.
 inventorybags_enable_item_teleportation_bag(Enable Item Teleportation Bag) bool false
 
-# Used to dialable the Bag of Winds
-inventorybags_dialable_bag_of_winds(Dialables the Bag of Winds) bool false
+# Used to disable the Bag of Winds
+# Note: The Bag of Winds does not work in MineClone, and is therefore disabled regardless of this setting.
+inventorybags_disable_bag_of_winds(Disable Bag of Winds) bool false


### PR DESCRIPTION
I didn't need to change much besides crafting recipes and formspecs to get this working. It still works with Minetest Game, and everything works with MineClone except the following things:

The Bag of Winds doesn't work in MineClone (simply doesn't change the gravity), so it's disabled in MineClone, although it works fine in Minetest Game.

Collecting upgrades don't really work as well in MineClone (only collecting when the bag is opened), since MineClone picks things up differently. I looked through MineClone's code, and I don't really see a way to make it work.

Proximity checks still break the Item Teleportation Bag (but you can use it to pull levers/push buttons remotely, which is pretty cool).